### PR TITLE
Dev/dont save fdt img

### DIFF
--- a/NFACT/preprocess/nfactpp_args.py
+++ b/NFACT/preprocess/nfactpp_args.py
@@ -175,6 +175,16 @@ def nfact_pp_args() -> dict:
         across all subjects.
         """,
     )
+    tractography_input.add_argument(
+        "-D",
+        "--dont_save_fdt_img",
+        action="store_true",
+        default=False,
+        dest="dont_save_fdt_img",
+        help="""
+        Don't save the fdt path as a nifti file. This is useful to save space
+        """,
+    )
     parallel_args(
         base_args,
         col,

--- a/NFACT/preprocess/probtrackx_functions.py
+++ b/NFACT/preprocess/probtrackx_functions.py
@@ -248,7 +248,7 @@ def build_probtrackx2_arguments(arg: dict, sub: str, ptx_options=False) -> list:
         f"--nsamples={arg['nsamples']}",
         f"--dir={output_dir}",
     ]
- 
+
     command.extend(warp_options)
     if arg["exclusion"]:
         command.extend(exclsuion_mask(arg["exclusion"]))
@@ -260,7 +260,7 @@ def build_probtrackx2_arguments(arg: dict, sub: str, ptx_options=False) -> list:
         )
     if "waypoints" in arg.keys():
         command.extend([f'--waypoints={os.path.join(sub, arg["waypoints"])}'])
-    if not arg['dont_save_fdt_img']:
+    if not arg["dont_save_fdt_img"]:
         command.append("--opd")
     if ptx_options:
         command.extend(ptx_options)

--- a/NFACT/preprocess/probtrackx_functions.py
+++ b/NFACT/preprocess/probtrackx_functions.py
@@ -244,12 +244,11 @@ def build_probtrackx2_arguments(arg: dict, sub: str, ptx_options=False) -> list:
         f"--target2={target_mask}",
         "--loopcheck",
         "--forcedir",
-        "--opd",
         "--pd",
         f"--nsamples={arg['nsamples']}",
         f"--dir={output_dir}",
     ]
-
+ 
     command.extend(warp_options)
     if arg["exclusion"]:
         command.extend(exclsuion_mask(arg["exclusion"]))
@@ -261,6 +260,8 @@ def build_probtrackx2_arguments(arg: dict, sub: str, ptx_options=False) -> list:
         )
     if "waypoints" in arg.keys():
         command.extend([f'--waypoints={os.path.join(sub, arg["waypoints"])}'])
+    if not arg['dont_save_fdt_img']:
+        command.append("--opd")
     if ptx_options:
         command.extend(ptx_options)
     return command

--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ Tractography options:
                         Use wtstop and stop in the tractography. Takes an absolute file path to a json file containing stop and wtstop masks, JSON keys must be stopping_mask and wtstop_mask. Argument can be used with the --filetree, in that case no json file is
                         needed.
   -A, --absolute        Treat seeds and rois as absolute paths, providing one set of seeds and rois for tractography across all subjects.
+  -D, --dont_save_fdt_img
+                        Don't save the fdt path as a nifti file. This is useful to save space
+
 
 Parallel Processing arguments:
   -n N_CORES, --n_cores N_CORES


### PR DESCRIPTION
1) Added into nfact_pp the ability to not save the fdt path image as this takes up a lot of space.